### PR TITLE
Issue 398 - Typo in error message 42 - invalid relatvie offset expres…

### DIFF
--- a/rt/bat/RUNASMTESTS.BAT
+++ b/rt/bat/RUNASMTESTS.BAT
@@ -13,21 +13,23 @@ set /A z_NestLevel=%z_NestLevel%+1
 rem ----- Lvl(%z_NestLevel%) Start %0 %1 %2 %3 %4 %5 %6 %7 %8 %9
 
 pushd %~dps0..\..
-call bat\asm   %z_TraceMode% tests\testins1 trace sysmac(mac) noloadhigh               || goto error
-call bat\asmlg %z_TraceMode% tests\testins2 trace sysmac(mac) noloadhigh               || goto error
-call bat\asmlg %z_TraceMode% tests\testins3 trace sysmac(mac) noloadhigh               || goto error
-call bat\asmlg %z_TraceMode% tests\testins4 trace sysmac(mac) noloadhigh               || goto error
-call bat\asmlg %z_TraceMode% tests\testins5 trace sysmac(mac) noloadhigh optable(z390) || goto error
-call bat\asmlg %z_TraceMode% tests\testdfp1 trace sysmac(mac) noloadhigh optable(z390) || goto error
-call bat\asmlg %z_TraceMode% tests\testdfp2 trace sysmac(mac) noloadhigh optable(z390) || goto error
-call bat\asmlg %z_TraceMode% tests\testlits trace sysmac(mac) noloadhigh optable(z390) || goto error
-call bat\asmlg %z_TraceMode% rt\mlc\TESTAMPS trace sysmac(mac) noloadhigh optable(z390) || goto error
-call bat\asmlg %z_TraceMode% rt\mlc\IS215 trace sysmac(mac) noloadhigh optable(z390) || goto error
-call bat\asmlg %z_TraceMode% rt\mlc\TESTDC1 trace sysmac(mac) noloadhigh optable(z390) || goto error
-call bat\asmlg %z_TraceMode% rt\mlc\TESTASC1 ASCII trace sysmac(mac) noloadhigh optable(z390) || goto error
-call bat\asmlg %z_TraceMode% rt\mlc\TESTDC2 trace sysmac(mac) noloadhigh optable(z390) || goto error
-call bat\asmlg %z_TraceMode% rt\mlc\TESTDC3 trace sysmac(mac) noloadhigh optable(z390) || goto error
-call rt\bat\ZOPCHECK %z_TraceMode%                                                     || goto error
+call bat\asm   %z_TraceMode% tests\testins1  trace sysmac(mac) noloadhigh                     || goto error
+call bat\asmlg %z_TraceMode% tests\testins2  trace sysmac(mac) noloadhigh                     || goto error
+call bat\asmlg %z_TraceMode% tests\testins3  trace sysmac(mac) noloadhigh                     || goto error
+call bat\asmlg %z_TraceMode% tests\testins4  trace sysmac(mac) noloadhigh                     || goto error
+call bat\asmlg %z_TraceMode% tests\testins5  trace sysmac(mac) noloadhigh optable(z390)       || goto error
+call bat\asmlg %z_TraceMode% tests\testdfp1  trace sysmac(mac) noloadhigh optable(z390)       || goto error
+call bat\asmlg %z_TraceMode% tests\testdfp2  trace sysmac(mac) noloadhigh optable(z390)       || goto error
+call bat\asmlg %z_TraceMode% tests\testlits  trace sysmac(mac) noloadhigh optable(z390)       || goto error
+call bat\asmlg %z_TraceMode% rt\mlc\TESTAMPS trace sysmac(mac) noloadhigh optable(z390)       || goto error
+call bat\asmlg %z_TraceMode% rt\mlc\IS215    trace sysmac(mac) noloadhigh optable(z390)       || goto error
+call bat\asmlg %z_TraceMode% rt\mlc\TESTDC1  trace sysmac(mac) noloadhigh optable(z390)       || goto error
+call bat\asmlg %z_TraceMode% rt\mlc\TESTASC1 trace sysmac(mac) noloadhigh optable(z390) ASCII || goto error
+call bat\asmlg %z_TraceMode% rt\mlc\TESTDC2  trace sysmac(mac) noloadhigh optable(z390)       || goto error
+call bat\asmlg %z_TraceMode% rt\mlc\TESTDC3  trace sysmac(mac) noloadhigh optable(z390)       || goto error
+call rt\bat\ZOPCHECK %z_TraceMode%                                                            || goto error
+
+rem -- all checks passed without issue
 set z_ReturnCode=0
 goto return
 

--- a/rt/bat/readme.txt
+++ b/rt/bat/readme.txt
@@ -13,6 +13,4 @@ RUNTESTOPT  - verify indirection usage in options files
 
 Double click on above commands to run them.
 
-See issue #
-
 don@higgins.net 2021-04-29

--- a/rt/mlc/IS00398.MLC
+++ b/rt/mlc/IS00398.MLC
@@ -1,9 +1,0 @@
-TESTB    START 0
-         USING *,13
-         STM   14,12,12(13)
-         ST    13,8(13)
-         ST    15,4(15)
-         LR    13,15
-         J
-         RETURN (14,12)
-         END   TESTB

--- a/src/az390.java
+++ b/src/az390.java
@@ -416,6 +416,7 @@ public  class  az390 implements Runnable {
         * 2022-01-16 DSH #343 move abort for exceeding maxline 
         * 2022-03-28 DSH #327 fix az390 to force odd literals to even address for access by relative halfword offset counts	
         * 2022-05-07 DSH #233 allow spaces within DC numberic values for BDEFHLPXZ such as DC F'123 456' same as F'123456'
+        * 2022-05-10 AFK #398 fix typo in error message and report relative paths (rather than absolute ones) when in RT mode (NOTIMING option in effect)
 	*****************************************************
     * Global variables                        last rpi
     *****************************************************/
@@ -7065,8 +7066,21 @@ public void put_stats(){
 	while (index < tot_xref_files){
 		if (mz390_call && xref_file_errors[index] > 0){  // RPI 935
 			String xref_msg = "FID=" + tz390.right_justify(""+(index+1),3) 
-					        + " ERR=" + tz390.right_justify(""+xref_file_errors[index],4) 
- 	                        + " " + xref_file_name[index];
+					        + " ERR=" + tz390.right_justify(""+xref_file_errors[index],4);
+        // Add file with absolute path - only in RT mode as indicated by option notiming use relative path
+        if (tz390.opt_timing                                         // timing: absolute path
+         || xref_file_name[index].length() <= tz390.dir_cur.length() // not subdir of current directory
+            )
+           {xref_msg = xref_msg + " " + xref_file_name[index];
+            }
+        else
+           {if (xref_file_name[index].substring(0,tz390.dir_cur.length()).equals(tz390.dir_cur)) // leading part of path matches current dir
+               {xref_msg = xref_msg + " ." + xref_file_name[index].substring(tz390.dir_cur.length()-1);
+                }
+            else // no match - use full path anyway
+               {xref_msg = xref_msg + " " + xref_file_name[index];
+                }
+            } //**!! tz390.dir_cur 
 			put_log(msg_id + xref_msg);
 		    tz390.put_systerm(msg_id + xref_msg);
 		}
@@ -8170,7 +8184,7 @@ private void get_hex_relative_offset(int bits){
 		}
 	} else {
 		obj_code = obj_code + "iiiiiiii";		
-		log_error(42,"invalid relatvie offset expression");
+		log_error(42,"invalid relative offset expression");
 	}
 }
 private void get_hex_byte_signed(){


### PR DESCRIPTION
…sion (#407)

* fix typo in az390 error message

* Fix typo in error message and add regression test case

* use relative paths in error messages when NOTIMING is in effect

* Remove RT logic for this simple typo being fixed